### PR TITLE
Changed parameter of setting update callback to subscription

### DIFF
--- a/lib/Albinos.h
+++ b/lib/Albinos.h
@@ -58,7 +58,7 @@ namespace Albinos
     ///
     /// \brief type of function pointer for setting change subscription
     ///
-    typedef void (*FCPTR_ON_CHANGE_NOTIFIER)(void *data, enum ModifType);
+    typedef void (*FCPTR_ON_CHANGE_NOTIFIER)(struct Subscription const *, enum ModifType);
 
     ///
     /// \brief indicate the key type
@@ -123,6 +123,8 @@ namespace Albinos
     /// \return error code
     ///
     /// To stop the subscription, `unsubsribe` must be called.
+    /// To get the subsrption's user data one can use `getSubscriptionUserData`
+    /// To get the subsrption's setting name one can use `getSubscriptionSettingName`
     ///
     enum ReturnedValue subscribeToSetting(struct Config*, char const *name, void *data, FCPTR_ON_CHANGE_NOTIFIER onChange, struct Subscription **subscription);
 
@@ -327,7 +329,7 @@ namespace Albinos
     /// \brief be notified when a setting change
     /// \param the config
     /// \param 'name' setting you want to watch
-    /// \param 'data' point to userdata, which will be forwarded to the callback
+    /// \param 'data' point to userdata, which will be available in from the subscription in the callback
     /// \param 'onChange' function pointer callback which will be called once for each setting change
     /// \param 'subscription' in case of success, a new 'struct Subscription' will be written
     /// \return error code
@@ -342,6 +344,23 @@ namespace Albinos
     /// \return error code
     ///
     enum ReturnedValue pollSubscriptions(struct Config*);
+
+    /// Query functions:
+
+    ///
+    /// \brief get a subscription's user data
+    /// \param 'subscription' the subscription to query the user data from
+    /// \return the user data
+    ///
+    void *getSupscriptionUserData(struct Subscription const *);
+
+    ///
+    /// \brief get a subscription's setting name
+    /// \param 'subscription' the subscription to query the setting name from
+    /// \return the setting name
+    ///
+    char const *getSupscriptionSettingName(struct Subscription const *);
+
 
 #ifdef __cplusplus
   }

--- a/lib/Subscription.cpp
+++ b/lib/Subscription.cpp
@@ -16,10 +16,15 @@ Albinos::Subscription::~Subscription()
 
 void Albinos::Subscription::executeCallBack(ModifType modif) const
 {
-  callBack(associatedData, modif);
+  callBack(this, modif);
 }
 
 std::string const &Albinos::Subscription::getAssociatedSetting() const
 {
   return associatedSetting;
+}
+
+void *Albinos::Subscription::getAssociatedUserData() const
+{
+  return associatedData;
 }

--- a/lib/Subscription.hpp
+++ b/lib/Subscription.hpp
@@ -34,6 +34,7 @@ namespace Albinos
 
     void executeCallBack(ModifType) const;
     std::string const &getAssociatedSetting() const;
+    void *getAssociatedUserData() const;
 
   };
 }

--- a/lib/funcHub.cpp
+++ b/lib/funcHub.cpp
@@ -1,4 +1,5 @@
-# include "funcHub.hpp"
+#include "funcHub.hpp"
+#include "Subscription.hpp"
 
 void Albinos::unsubscribe(Subscription *sub)
 {
@@ -200,4 +201,14 @@ Albinos::ReturnedValue Albinos::pollSubscriptions(Config *config)
   if (!config)
     return BAD_PARAMETERS;
   return config->pollSubscriptions();
+}
+
+void *Albinos::getSupscriptionUserData(struct Albinos::Subscription const *subsription)
+{
+  return subsription->getAssociatedUserData();
+}
+
+char const *Albinos::getSupscriptionSettingName(struct Albinos::Subscription const *subsription)
+{
+  return subsription->getAssociatedSetting().c_str();
 }


### PR DESCRIPTION
Also added two functions to Albinos.h:
- getSupscriptionUserData
- getSupscriptionSettingName

This makes callbacks far more usable, because you don't need to store the setting modified or the subscription itself anymore.